### PR TITLE
Feature: delete product

### DIFF
--- a/README-DevEnv.md
+++ b/README-DevEnv.md
@@ -54,39 +54,42 @@ $ conda deactivate nameko-devex
 (nameko-devex) ./test/nex-smoketest.sh local 
 
 # Example output:
-Local Development
+Local Smoke Test
 STD_APP_URL=http://localhost:8000
 === Creating a product id: the_odyssey ===
 {"id": "the_odyssey"}
 === Getting product id: the_odyssey ===
 {
-  "in_stock": 10,
-  "id": "the_odyssey",
   "maximum_speed": 5,
+  "id": "the_odyssey",
+  "title": "The Odyssey",
   "passenger_capacity": 101,
-  "title": "The Odyssey"
+  "in_stock": 10
 }
+=== Deleting product id: soon_to_be_deleted ===
+{"id": "soon_to_be_deleted"}
+204
 === Creating Order ===
-{"id": 3}
+{"id": 6017}
 === Getting Order ===
 {
+  "id": 6017,
   "order_details": [
     {
+      "id": 6017,
+      "product": {
+        "maximum_speed": 5,
+        "id": "the_odyssey",
+        "title": "The Odyssey",
+        "passenger_capacity": 101,
+        "in_stock": 9
+      },
+      "quantity": 1,
       "image": "http://www.example.com/airship/images/the_odyssey.jpg",
       "price": "100000.99",
-      "product_id": "the_odyssey",
-      "id": 3,
-      "product": {
-        "in_stock": 9,
-        "id": "the_odyssey",
-        "maximum_speed": 5,
-        "passenger_capacity": 101,
-        "title": "The Odyssey"
-      },
-      "quantity": 1
+      "product_id": "the_odyssey"
     }
-  ],
-  "id": 3
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ $ curl 'http://localhost:8003/products/the_odyssey'
   "in_stock": 10
 }
 ```
+
+### Delete Product
+
+```sh
+$ curl -XDELETE 'http://localhost:8003/products/the_odyssey'
+```
+
 #### Create Order
 
 ```sh

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -74,6 +74,19 @@ class GatewayService(object):
             json.dumps({'id': product_data['id']}), mimetype='application/json'
         )
 
+    @http("DELETE", "/products/<string:product_id>")
+    def delete_product(self, request, product_id):
+        """Delete product by `product_id`.
+        If the product does not exist, a 404 response is returned.
+        """
+        deleted = self.products_rpc.delete(product_id)
+
+        print("DELETE PRODUCT: ", deleted)
+        if not deleted:
+            return Response(status=404)
+
+        return Response(status=204)
+
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):
         """Gets the order details for the order given by `order_id`.

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -81,6 +81,26 @@ class TestCreateProduct(object):
         assert response.json()['error'] == 'VALIDATION_ERROR'
 
 
+class TestDeleteProduct(object):
+    def test_can_delete_product(self, gateway_service, web_session):
+        response = web_session.delete('/products/the_odyssey')
+        assert response.status_code == 204
+        assert gateway_service.products_rpc.delete.call_args_list == [call(
+            'the_odyssey'
+        )]
+
+    def test_delete_product_fails_with_invalid_data(
+        self, gateway_service, web_session
+    ):
+        # Configure the MagicMock to return 0 for a failed deletion
+        gateway_service.products_rpc.delete.return_value = False
+
+        response = web_session.delete('/products/invalid_id')
+        assert response.status_code == 404
+        assert gateway_service.products_rpc.delete.call_args_list == [call(
+            'invalid_id'
+        )]
+
 class TestGetOrder(object):
 
     def test_can_get_order(self, gateway_service, web_session):

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -48,6 +48,9 @@ class StorageWrapper:
         for key in keys:
             yield self._from_hash(self.client.hgetall(key))
 
+    def delete(self, product_id):
+        return bool(self.client.delete(self._format_key(product_id)))
+
     def create(self, product):
         self.client.hmset(
             self._format_key(product['id']),

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -21,6 +21,10 @@ class ProductsService:
         return schemas.Product().dump(product).data
 
     @rpc
+    def delete(self, product_id):
+        return self.storage.delete(product_id)
+
+    @rpc
     def list(self):
         products = self.storage.list()
         return schemas.Product(many=True).dump(products).data

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -31,6 +31,27 @@ def test_get_product_fails_on_not_found(service_container):
         with entrypoint_hook(service_container, 'get') as get:
             get(111)
 
+def test_delete_product(create_product, service_container):
+
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, 'delete') as delete:
+        deleted = delete(stored_product['id'])
+
+    assert deleted
+
+    with pytest.raises(NotFound):
+        with entrypoint_hook(service_container, 'get') as get:
+            get(stored_product['id'])
+
+def test_delete_product_fails_on_not_found(service_container):
+
+    with entrypoint_hook(service_container, 'delete') as delete:
+        deleted = delete('invalid_id')
+
+    assert not deleted
+
+
 
 def test_list_products(products, service_container):
 

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -108,6 +108,18 @@ scenarios:
     - if: '"${order_id}" == "NOT_FOUND"'
       then:
         - action: continue
+
+    # 5. Delete Product
+    - url: /products/${product_id}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+
+      assert:
+      - contains:
+        - 204
+        subject: http-code
+        not: false
   
 reporting:
 - module: final-stats

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -34,9 +34,19 @@ curl -s -XPOST  "${STD_APP_URL}/products" \
     -H 'Content-Type: application/json' \
     -d '{"id": "the_odyssey", "title": "The Odyssey", "passenger_capacity": 101, "maximum_speed": 5, "in_stock": 10}'
 echo
+
 # Test: Get Product
 echo "=== Getting product id: the_odyssey ==="
 curl -s "${STD_APP_URL}/products/the_odyssey" | jq .
+
+# Test: Delete Product
+echo "=== Deleting product id: soon_to_be_deleted ==="
+curl -s -XPOST  "${STD_APP_URL}/products" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{"id": "soon_to_be_deleted", "title": "The Odyssey", "passenger_capacity": 101, "maximum_speed": 5, "in_stock": 10}'
+echo
+curl -s -XDELETE "${STD_APP_URL}/products/soon_to_be_deleted" -o /dev/null -w "%{http_code}\n"
 
 # Test: Create Order
 echo "=== Creating Order ==="


### PR DESCRIPTION
## Context
This pull request adds a new feature to the gateway and products services that allows deleting a product by its id. It also includes tests for the delete product endpoint and method in both services. The feature is implemented using the HTTP DELETE method and returns a 204 status code on success or a 404 status code on failure. The pull request also updates the smoke test and the performance test scripts to include the delete product feature.

## Checklist
- [x] Added or updated tests.
- [x] Ensured proper formatting of files.
- [x] Ran and ensured no degradation in performance tests.
- [x] Updated documentation.
