### PR TITLE
Feature: list orders

### DIFF
--- a/README-DevEnv.md
+++ b/README-DevEnv.md
@@ -95,6 +95,7 @@ STD_APP_URL=http://localhost:8000
 {
   "page": 1,
   "total_pages": 1,
+  "total_orders": 1,
   "orders": [
     {
       "order_details": [

--- a/README-DevEnv.md
+++ b/README-DevEnv.md
@@ -60,36 +60,36 @@ STD_APP_URL=http://localhost:8000
 {"id": "the_odyssey"}
 === Getting product id: the_odyssey ===
 {
-  "passenger_capacity": 101,
-  "title": "The Odyssey",
+  "id": "the_odyssey",
   "maximum_speed": 5,
   "in_stock": 10,
-  "id": "the_odyssey"
+  "passenger_capacity": 101,
+  "title": "The Odyssey"
 }
 === Deleting product id: soon_to_be_deleted ===
 {"id": "soon_to_be_deleted"}
 204
 === Creating Order ===
-{"id": 6020}
+{"id": 9813}
 === Getting Order ===
 {
   "order_details": [
     {
-      "image": "http://www.example.com/airship/images/the_odyssey.jpg",
-      "product": {
-        "passenger_capacity": 101,
-        "title": "The Odyssey",
-        "maximum_speed": 5,
-        "in_stock": 9,
-        "id": "the_odyssey"
-      },
+      "id": 9813,
       "price": "100000.99",
+      "image": "http://www.example.com/airship/images/the_odyssey.jpg",
       "quantity": 1,
       "product_id": "the_odyssey",
-      "id": 6020
+      "product": {
+        "id": "the_odyssey",
+        "maximum_speed": 5,
+        "in_stock": 9,
+        "passenger_capacity": 101,
+        "title": "The Odyssey"
+      }
     }
   ],
-  "id": 6020
+  "id": 9813
 }
 === Listing Orders ===
 {
@@ -99,13 +99,21 @@ STD_APP_URL=http://localhost:8000
     {
       "order_details": [
         {
+          "id": 9813,
+          "price": "100000.99",
           "quantity": 1,
           "product_id": "the_odyssey",
-          "id": 6020,
-          "price": "100000.99"
+          "product": {
+            "id": "the_odyssey",
+            "maximum_speed": 5,
+            "in_stock": 9,
+            "passenger_capacity": 101,
+            "title": "The Odyssey"
+          },
+          "image": "http://www.example.com/airship/images/the_odyssey.jpg"
         }
       ],
-      "id": 6020
+      "id": 9813
     }
   ]
 }

--- a/README-DevEnv.md
+++ b/README-DevEnv.md
@@ -60,34 +60,52 @@ STD_APP_URL=http://localhost:8000
 {"id": "the_odyssey"}
 === Getting product id: the_odyssey ===
 {
-  "maximum_speed": 5,
-  "id": "the_odyssey",
-  "title": "The Odyssey",
   "passenger_capacity": 101,
-  "in_stock": 10
+  "title": "The Odyssey",
+  "maximum_speed": 5,
+  "in_stock": 10,
+  "id": "the_odyssey"
 }
 === Deleting product id: soon_to_be_deleted ===
 {"id": "soon_to_be_deleted"}
 204
 === Creating Order ===
-{"id": 6017}
+{"id": 6020}
 === Getting Order ===
 {
-  "id": 6017,
   "order_details": [
     {
-      "id": 6017,
-      "product": {
-        "maximum_speed": 5,
-        "id": "the_odyssey",
-        "title": "The Odyssey",
-        "passenger_capacity": 101,
-        "in_stock": 9
-      },
-      "quantity": 1,
       "image": "http://www.example.com/airship/images/the_odyssey.jpg",
+      "product": {
+        "passenger_capacity": 101,
+        "title": "The Odyssey",
+        "maximum_speed": 5,
+        "in_stock": 9,
+        "id": "the_odyssey"
+      },
       "price": "100000.99",
-      "product_id": "the_odyssey"
+      "quantity": 1,
+      "product_id": "the_odyssey",
+      "id": 6020
+    }
+  ],
+  "id": 6020
+}
+=== Listing Orders ===
+{
+  "page": 1,
+  "total_pages": 1,
+  "orders": [
+    {
+      "order_details": [
+        {
+          "quantity": 1,
+          "product_id": "the_odyssey",
+          "id": 6020,
+          "price": "100000.99"
+        }
+      ],
+      "id": 6020
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -130,7 +130,15 @@ $ curl 'http://localhost:8003/orders?page=1'
 					"quantity": 1,
 					"price": "100000.99",
 					"id": 1,
-					"product_id": "the_odyssey"
+          "image": "http://www.example.com/airship/images/the_odyssey.jpg",
+					"product_id": "the_odyssey",
+          "product": {
+            "maximum_speed": 5,
+            "id": "the_odyssey",
+            "title": "The Odyssey",
+            "passenger_capacity": 101,
+            "in_stock": 9
+          }
 				}
 			]
     }

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ $ curl 'http://localhost:8003/orders?page=1'
 {
 	"page": 1,
 	"total_pages": 1,
+  "total_orders": 1,
 	"orders": [
     {
       "id": 1,

--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ $ curl 'http://localhost:8003/orders/1'
 }
 ```
 
+#### List Orders
+
+```sh
+$ curl 'http://localhost:8003/orders?page=1'
+
+{
+	"page": 1,
+	"total_pages": 1,
+	"orders": [
+    {
+      "id": 1,
+      "order_details": [
+				{
+					"quantity": 1,
+					"price": "100000.99",
+					"id": 1,
+					"product_id": "the_odyssey"
+				}
+			]
+    }
+  ]
+}
+```
+
 ## Running tests
 
 Ensure RabbitMQ, PostgreSQL and Redis are running and `config.yaml` files for each service are configured correctly.

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -96,6 +96,14 @@ class GatewayService(object):
         page = int(request.args.get('page', 1))
         orders = self.orders_rpc.list_orders(page)
 
+        for order in orders['orders']:
+            for item in order['order_details']:
+                product_id = item['product_id']
+                item['product'] = self.products_rpc.get(product_id)
+                item['image'] = '{}/{}.jpg'.format(
+                    config['PRODUCT_IMAGE_ROOT'], product_id
+                )
+
         return Response(
             json.dumps(orders), mimetype='application/json'
         )

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -81,7 +81,6 @@ class GatewayService(object):
         """
         deleted = self.products_rpc.delete(product_id)
 
-        print("DELETE PRODUCT: ", deleted)
         if not deleted:
             return Response(status=404)
 

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -87,6 +87,19 @@ class GatewayService(object):
 
         return Response(status=204)
 
+    @http("GET", "/orders")
+    def list_orders(self, request):
+        """Lists orders.
+        Supports pagination using the `page` query parameter.
+        """
+
+        page = int(request.args.get('page', 1))
+        orders = self.orders_rpc.list_orders(page)
+
+        return Response(
+            json.dumps(orders), mimetype='application/json'
+        )
+
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):
         """Gets the order details for the order given by `order_id`.

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -101,6 +101,53 @@ class TestDeleteProduct(object):
             'invalid_id'
         )]
 
+
+class TestListOrders(object):
+    def test_can_list_orders(self, gateway_service, web_session):
+        expected_response = {
+            'page': 1,
+            'total_pages': 1,
+            'orders': [
+                {
+                    'id': 1,
+                    'order_details': [
+                        {
+                            'id': 1,
+                            'quantity': 2,
+                            'product_id': 'the_odyssey',
+                            'price': '200.00'
+                        },
+                        {
+                            'id': 2,
+                            'quantity': 1,
+                            'product_id': 'the_enigma',
+                            'price': '400.00'
+                        }
+                    ]
+                },
+                {
+                    'id': 2,
+                    'order_details': [
+                        {
+                            'id': 3,
+                            'quantity': 1,
+                            'product_id': 'the_odyssey',
+                            'price': '200.00'
+                        }
+                    ]
+                }
+            ]
+        }
+
+        # setup mock orders-service response:
+        gateway_service.orders_rpc.list_orders.return_value = expected_response
+
+        # call the gateway service to list orders
+        response = web_session.get('/orders')
+        assert response.status_code == 200
+        assert response.json() == expected_response
+
+
 class TestGetOrder(object):
 
     def test_can_get_order(self, gateway_service, web_session):

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -104,7 +104,9 @@ class TestDeleteProduct(object):
 
 class TestListOrders(object):
     def test_can_list_orders(self, gateway_service, web_session):
-        expected_response = {
+        
+        # setup mock orders-service response:
+        gateway_service.orders_rpc.list_orders.return_value = {
             'page': 1,
             'total_pages': 1,
             'orders': [
@@ -116,36 +118,52 @@ class TestListOrders(object):
                             'quantity': 2,
                             'product_id': 'the_odyssey',
                             'price': '200.00'
-                        },
-                        {
-                            'id': 2,
-                            'quantity': 1,
-                            'product_id': 'the_enigma',
-                            'price': '400.00'
-                        }
-                    ]
-                },
-                {
-                    'id': 2,
-                    'order_details': [
-                        {
-                            'id': 3,
-                            'quantity': 1,
-                            'product_id': 'the_odyssey',
-                            'price': '200.00'
                         }
                     ]
                 }
             ]
         }
 
-        # setup mock orders-service response:
-        gateway_service.orders_rpc.list_orders.return_value = expected_response
+        # setup mock products-service responses:
+        gateway_service.products_rpc.get.side_effect = [
+            {
+                'id': 'the_odyssey',
+                'title': 'The Odyssey',
+                'maximum_speed': 3,
+                'in_stock': 899,
+                'passenger_capacity': 100
+            }
+        ]
 
         # call the gateway service to list orders
         response = web_session.get('/orders')
+        print(response.json())
         assert response.status_code == 200
-        assert response.json() == expected_response
+        assert response.json() == {
+            'page': 1,
+            'total_pages': 1,
+            'orders': [
+                {
+                    'id': 1,
+                    'order_details': [
+                        {
+                            'id': 1,
+                            'quantity': 2,
+                            'product_id': 'the_odyssey',
+                            'price': '200.00',
+                            'image': 'http://example.com/airship/images/the_odyssey.jpg',
+                            'product': {
+                                'id': 'the_odyssey',
+                                'title': 'The Odyssey',
+                                'maximum_speed': 3,
+                                'in_stock': 899,
+                                'passenger_capacity': 100
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
 
 
 class TestGetOrder(object):

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -106,23 +106,20 @@ class TestListOrders(object):
     def test_can_list_orders(self, gateway_service, web_session):
         
         # setup mock orders-service response:
-        gateway_service.orders_rpc.list_orders.return_value = {
-            'page': 1,
-            'total_pages': 1,
-            'orders': [
-                {
-                    'id': 1,
-                    'order_details': [
-                        {
-                            'id': 1,
-                            'quantity': 2,
-                            'product_id': 'the_odyssey',
-                            'price': '200.00'
-                        }
-                    ]
-                }
-            ]
-        }
+        gateway_service.orders_rpc.count_orders.return_value = 1
+        gateway_service.orders_rpc.list_orders.return_value = [
+            {
+                'id': 1,
+                'order_details': [
+                    {
+                        'id': 1,
+                        'quantity': 2,
+                        'product_id': 'the_odyssey',
+                        'price': '200.00'
+                    }
+                ]
+            }
+        ]
 
         # setup mock products-service responses:
         gateway_service.products_rpc.get.side_effect = [
@@ -142,6 +139,7 @@ class TestListOrders(object):
         assert response.json() == {
             'page': 1,
             'total_pages': 1,
+            'total_orders': 1,
             'orders': [
                 {
                     'id': 1,

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -104,7 +104,7 @@ class TestDeleteProduct(object):
 
 class TestListOrders(object):
     def test_can_list_orders(self, gateway_service, web_session):
-        
+
         # setup mock orders-service response:
         gateway_service.orders_rpc.count_orders.return_value = 1
         gateway_service.orders_rpc.list_orders.return_value = [
@@ -134,7 +134,8 @@ class TestListOrders(object):
 
         # call the gateway service to list orders
         response = web_session.get('/orders')
-        print(response.json())
+
+        imagem_url = 'http://example.com/airship/images/the_odyssey.jpg'
         assert response.status_code == 200
         assert response.json() == {
             'page': 1,
@@ -149,7 +150,7 @@ class TestListOrders(object):
                             'quantity': 2,
                             'product_id': 'the_odyssey',
                             'price': '200.00',
-                            'image': 'http://example.com/airship/images/the_odyssey.jpg',
+                            'image': imagem_url,
                             'product': {
                                 'id': 'the_odyssey',
                                 'title': 'The Odyssey',

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -14,22 +14,13 @@ class OrdersService:
     event_dispatcher = EventDispatcher()
 
     @rpc
-    def list_orders(self, page=1):
-        per_page = 10
-
-        offset = (page - 1) * per_page
-        orders = self.db.query(Order).limit(per_page).offset(offset).all()
-
-        total_orders = self.db.query(Order).count()
-        total_pages = total_orders // per_page + (total_orders % per_page > 0)
-
-        print(orders)
-
-        return {
-            'page': page,
-            'total_pages': total_pages,
-            'orders': OrderSchema().dump(orders, many=True).data
-        }
+    def list_orders(self, offset=0, limit=10):
+        orders = self.db.query(Order).limit(limit).offset(offset).all()
+        return OrderSchema().dump(orders, many=True).data
+    
+    @rpc
+    def count_orders(self):
+        return self.db.query(Order).count()
 
     @rpc
     def get_order(self, order_id):

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -14,6 +14,24 @@ class OrdersService:
     event_dispatcher = EventDispatcher()
 
     @rpc
+    def list_orders(self, page=1):
+        per_page = 10
+
+        offset = (page - 1) * per_page
+        orders = self.db.query(Order).limit(per_page).offset(offset).all()
+
+        total_orders = self.db.query(Order).count()
+        total_pages = total_orders // per_page + (total_orders % per_page > 0)
+
+        print(orders)
+
+        return {
+            'page': page,
+            'total_pages': total_pages,
+            'orders': OrderSchema().dump(orders, many=True).data
+        }
+
+    @rpc
     def get_order(self, order_id):
         order = self.db.query(Order).get(order_id)
 

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -17,7 +17,7 @@ class OrdersService:
     def list_orders(self, offset=0, limit=10):
         orders = self.db.query(Order).limit(limit).offset(offset).all()
         return OrderSchema().dump(orders, many=True).data
-    
+
     @rpc
     def count_orders(self):
         return self.db.query(Order).count()

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -31,43 +31,47 @@ def order_details(db_session, order):
     return order_details_list
 
 
-def test_can_list_orders_with_default_page(orders_rpc, order, order_details):
+def test_can_list_orders_with_default_options(orders_rpc, order, order_details):
     response = orders_rpc.list_orders()
-    assert response['page'] == 1
-    assert response['total_pages'] == 1
 
-    assert len(response['orders']) == 1
+    assert len(response) == 1
+    assert order.id == response[0]['id']
 
-    response_order = response['orders'][0]
-    assert order.id == response_order['id']
-
-    assert len(response_order['order_details']) == 2
-    assert response_order['order_details'][0]['product_id'] \
+    assert len(response[0]['order_details']) == 2
+    assert response[0]['order_details'][0]['product_id'] \
         == order_details[0].product_id
-    assert response_order['order_details'][1]['product_id'] \
+    assert response[0]['order_details'][1]['product_id'] \
         == order_details[1].product_id
 
 
 @pytest.mark.usefixtures('order')
-def test_can_list_orders_with_custom_page_without_data(orders_rpc):
-    response = orders_rpc.list_orders(2)
-    assert response['page'] == 2
-    assert response['total_pages'] == 1
-
-    assert len(response['orders']) == 0
+def test_can_list_orders_with_custom_options_without_data(orders_rpc):
+    response = orders_rpc.list_orders(10, 10)
+    assert len(response) == 0
 
 
 @pytest.mark.usefixtures('order')
-def test_can_list_orders_with_custom_page_with_data(db_session, orders_rpc):
-
+def test_can_list_orders_with_custom_options_with_data(db_session, orders_rpc):
     orders = [Order() for i in range(10)]
     db_session.add_all(orders)
     db_session.commit()
 
-    response = orders_rpc.list_orders(2)
-    assert response['page'] == 2
-    assert response['total_pages'] == 2
-    assert len(response['orders']) == 1
+    response = orders_rpc.list_orders(10, 10)
+    assert len(response) == 1
+
+@pytest.mark.usefixtures('order')
+def test_can_count_orders(orders_rpc):
+    response = orders_rpc.count_orders()
+    assert response == 1
+
+@pytest.mark.usefixtures('order')
+def test_can_count_orders_with_extra_data(db_session, orders_rpc):
+    orders = [Order() for i in range(10)]
+    db_session.add_all(orders)
+    db_session.commit()
+
+    response = orders_rpc.count_orders()
+    assert response == 11
 
 
 def test_get_order(orders_rpc, order):

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -31,7 +31,10 @@ def order_details(db_session, order):
     return order_details_list
 
 
-def test_can_list_orders_with_default_options(orders_rpc, order, order_details):
+def test_can_list_orders_with_default_options(
+        orders_rpc,
+        order,
+        order_details):
     response = orders_rpc.list_orders()
 
     assert len(response) == 1
@@ -59,10 +62,12 @@ def test_can_list_orders_with_custom_options_with_data(db_session, orders_rpc):
     response = orders_rpc.list_orders(10, 10)
     assert len(response) == 1
 
+
 @pytest.mark.usefixtures('order')
 def test_can_count_orders(orders_rpc):
     response = orders_rpc.count_orders()
     assert response == 1
+
 
 @pytest.mark.usefixtures('order')
 def test_can_count_orders_with_extra_data(db_session, orders_rpc):

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -31,6 +31,7 @@ def test_get_product_fails_on_not_found(service_container):
         with entrypoint_hook(service_container, 'get') as get:
             get(111)
 
+
 def test_delete_product(create_product, service_container):
 
     stored_product = create_product()
@@ -44,13 +45,13 @@ def test_delete_product(create_product, service_container):
         with entrypoint_hook(service_container, 'get') as get:
             get(stored_product['id'])
 
+
 def test_delete_product_fails_on_not_found(service_container):
 
     with entrypoint_hook(service_container, 'delete') as delete:
         deleted = delete('invalid_id')
 
     assert not deleted
-
 
 
 def test_list_products(products, service_container):

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -109,8 +109,40 @@ scenarios:
       then:
         - action: continue
 
-    # 5. Delete Product
-    - url: /products/${product_id}
+    # 5. List Orders
+    - url: /orders
+      label: orders-list
+      think-time: uniform(0s, 0s)
+      method: GET
+        
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+
+    # 6. Create a Product to Delete
+    - url: /products
+      label: products-create-to-delete
+      think-time: uniform(0s, 0s)
+      method: POST
+      headers:
+        cache-control: no-cache
+        Content-Type: application/json
+      body: >
+        {
+          "id": "product-to-delete-${__javaScript(Math.random())}",
+          "title": "Product to Delete",
+          "passenger_capacity": 50,
+          "maximum_speed": 3,
+          "in_stock": 5
+        }
+      extract-jsonpath:
+        product_to_delete: $.id
+        default: NOT_FOUND
+
+    # 7. Delete Product
+    - url: /products/${product_to_delete}
       label: product-delete
       think-time: uniform(0s, 0s)
       method: DELETE
@@ -120,7 +152,7 @@ scenarios:
         - 204
         subject: http-code
         not: false
-  
+
 reporting:
 - module: final-stats
   dump-xml: stats.xml

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -62,3 +62,7 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 # Test: Get Order back
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
+
+# Test: List Orders
+echo "=== Listing Orders ==="
+curl -s "${STD_APP_URL}/orders" | jq .


### PR DESCRIPTION
## Context
This pull request adds the functionality to list orders in the orders service and the api gateway. It supports pagination using the page query parameter and returns the orders as JSON objects. It also includes tests for the new methods and updates the existing ones.

## Checklist
- [x] Added or updated tests.
- [x] Ensured proper formatting of files.
- [x] Ran and ensured no degradation in performance tests.
- [x] Updated documentation.
