### PR TITLE
Fixes the performance issues of order routes

### DIFF
--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -54,12 +54,12 @@ class TestCreateProduct(object):
         assert response.status_code == 200
         assert response.json() == {'id': 'the_odyssey'}
         assert gateway_service.products_rpc.create.call_args_list == [call({
-                "in_stock": 10,
-                "maximum_speed": 5,
-                "id": "the_odyssey",
-                "passenger_capacity": 101,
-                "title": "The Odyssey"
-            })]
+            "in_stock": 10,
+            "maximum_speed": 5,
+            "id": "the_odyssey",
+            "passenger_capacity": 101,
+            "title": "The Odyssey"
+        })]
 
     def test_create_product_fails_with_invalid_json(
         self, gateway_service, web_session
@@ -122,7 +122,7 @@ class TestListOrders(object):
         ]
 
         # setup mock products-service responses:
-        gateway_service.products_rpc.get.side_effect = [
+        gateway_service.products_rpc.list.return_value = [
             {
                 'id': 'the_odyssey',
                 'title': 'The Odyssey',
@@ -188,7 +188,7 @@ class TestGetOrder(object):
         }
 
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
+        gateway_service.products_rpc.get.side_effect = [
             {
                 'id': 'the_odyssey',
                 'title': 'The Odyssey',
@@ -248,7 +248,6 @@ class TestGetOrder(object):
 
         # check dependencies called as expected
         assert [call(1)] == gateway_service.orders_rpc.get_order.call_args_list
-        assert [call()] == gateway_service.products_rpc.list.call_args_list
 
     def test_order_not_found(self, gateway_service, web_session):
         gateway_service.orders_rpc.get_order.side_effect = (
@@ -265,23 +264,15 @@ class TestGetOrder(object):
 class TestCreateOrder(object):
 
     def test_can_create_order(self, gateway_service, web_session):
+
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
-            {
-                'id': 'the_odyssey',
-                'title': 'The Odyssey',
-                'maximum_speed': 3,
-                'in_stock': 899,
-                'passenger_capacity': 100
-            },
-            {
-                'id': 'the_enigma',
-                'title': 'The Enigma',
-                'maximum_speed': 200,
-                'in_stock': 1,
-                'passenger_capacity': 4
-            },
-        ]
+        gateway_service.products_rpc.list.return_value = [{
+            'id': 'the_odyssey',
+            'title': 'The Odyssey',
+            'maximum_speed': 3,
+            'in_stock': 899,
+            'passenger_capacity': 100
+        }]
 
         # setup mock create response
         gateway_service.orders_rpc.create_order.return_value = {
@@ -304,7 +295,6 @@ class TestCreateOrder(object):
         )
         assert response.status_code == 200
         assert response.json() == {'id': 11}
-        assert gateway_service.products_rpc.list.call_args_list == [call()]
         assert gateway_service.orders_rpc.create_order.call_args_list == [
             call([
                 {'product_id': 'the_odyssey', 'quantity': 3, 'price': '41.00'}
@@ -343,22 +333,7 @@ class TestCreateOrder(object):
         self, gateway_service, web_session
     ):
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
-            {
-                'id': 'the_odyssey',
-                'title': 'The Odyssey',
-                'maximum_speed': 3,
-                'in_stock': 899,
-                'passenger_capacity': 100
-            },
-            {
-                'id': 'the_enigma',
-                'title': 'The Enigma',
-                'maximum_speed': 200,
-                'in_stock': 1,
-                'passenger_capacity': 4
-            },
-        ]
+        gateway_service.products_rpc.get.return_value = None
 
         # call the gateway service to create the order
         response = web_session.post(

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -43,10 +43,19 @@ class StorageWrapper:
         else:
             return self._from_hash(product)
 
-    def list(self):
-        keys = self.client.keys(self._format_key('*'))
+    def list(self, product_ids=None):
+        if product_ids:
+            keys = [self._format_key(product_id) for product_id in product_ids]
+        else:
+            keys = self.client.keys(self._format_key('*'))
+
+        pipeline = self.client.pipeline()
         for key in keys:
-            yield self._from_hash(self.client.hgetall(key))
+            pipeline.hgetall(key)
+
+        results = pipeline.execute()
+        for result in results:
+            yield self._from_hash(result)
 
     def delete(self, product_id):
         return bool(self.client.delete(self._format_key(product_id)))

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -25,8 +25,8 @@ class ProductsService:
         return self.storage.delete(product_id)
 
     @rpc
-    def list(self):
-        products = self.storage.list()
+    def list(self, product_ids=None):
+        products = self.storage.list(product_ids)
         return schemas.Product(many=True).dump(products).data
 
     @rpc

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -28,10 +28,22 @@ def test_get(storage, products):
     assert 11 == product['in_stock']
 
 
-def test_list(storage, products):
+def test_list_without_filter(storage, products):
     listed_products = storage.list()
-    assert (
-        products == sorted(list(listed_products), key=lambda x: x['id']))
+
+    assert products \
+        == sorted(list(listed_products), key=lambda x: x['id'])
+
+
+def test_list_with_filter(storage, create_product):
+    create_product(id='item_1', title='ITEM 1', in_stock=10)
+    product_2 = create_product(id='item_2', title='ITEM 2', in_stock=11)
+    product_3 = create_product(id='item_3', title='ITEM 3', in_stock=12)
+
+    listed_products = storage.list(['item_2', 'item_3'])
+
+    assert [product_2, product_3] \
+        == sorted(list(listed_products), key=lambda x: x['id'])
 
 
 def test_create(product, redis_client, storage):

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -62,7 +62,7 @@ def test_list_products(products, service_container):
     assert products == sorted(listed_products, key=lambda p: p['id'])
 
 
-def test_list_productis_when_empty(service_container):
+def test_list_products_when_empty(service_container):
 
     with entrypoint_hook(service_container, 'list') as list_:
         listed_products = list_()


### PR DESCRIPTION
## Context
As the performance test runs longer, the performance of the gateway routes `order-get` and `orders-create` starts to degrade. The longer the test goes on, the more degraded they become. The main cause of this issue is that these routes are fetching a full list of products in every request, and as time passes and the test continues, the number of products registered in the database increases.

To fix these performance issues, this PR:
* Improves the performance of the order routes by reducing the number of calls to the products service and using a pipeline to fetch multiple products at once.
* Modifies the list and create methods of the products dependencies and service to accept an optional list of product IDs as a filter.

There are some minor improvements in `orders-list` as well. Previously, it would fetch every product one by one to list its details. Now it fetches them all at once in a single RPC call.

#### BlazeMeter reports from before and affter
> Both tests were run with clean Redis and Postgres databases

<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/10376340/235326814-09209c6d-ff8b-4f89-9cb2-783456a5c1eb.png">
</details>

<details><summary>Affter</summary>
<img src="https://user-images.githubusercontent.com/10376340/235326996-b23ca899-eacd-48ba-9c39-516991926958.png">
</details>

## Checklist
- [x] Added or updated tests.
- [x] Ensured proper formatting of files.
- [x] Ran and ensured no degradation in performance tests.
